### PR TITLE
use app's config to select fields to be retrieved

### DIFF
--- a/DependencyInjection/AzineHybridAuthExtension.php
+++ b/DependencyInjection/AzineHybridAuthExtension.php
@@ -36,7 +36,8 @@ class AzineHybridAuthExtension extends Extension {
     const FILTER = "contact_filter";
     const GENDER_GUESSER = "gender_guesser";
     const STORE_FOR_USER = "store_for_user";
-    const STORE_AS_COOKIE = "store_as_cookie";
+		const STORE_AS_COOKIE = "store_as_cookie";
+		const FIELDS = "fields";
 
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,7 +46,10 @@ class Configuration implements ConfigurationInterface
 					        	->scalarNode(AzineHybridAuthExtension::KEY)->cannotBeEmpty()->end()
 					        	->scalarNode(AzineHybridAuthExtension::SECRET)->cannotBeEmpty()->end()
 					        ->end() // array
-				        ->end() // keys
+								->end() // keys
+								->arrayNode(AzineHybridAuthExtension::FIELDS)
+									->prototype('scalar')->end()
+								->end() // fields
 					->end() //children
 				->end() // prototype
 			->end() // array

--- a/Entity/UserContact.php
+++ b/Entity/UserContact.php
@@ -1,102 +1,56 @@
 <?php
-namespace Azine\HybridAuthBundle\Entity;
 
+namespace Azine\HybridAuthBundle\Entity;
 
 class UserContact {
 
-	/* The Unique contact user ID */
-	public $identifier = NULL;
+		/**
+		 * @var string
+		 */
+		public $provider = NULL;
+
+		/**
+		 * @var array
+		 */
+		protected $fields = [];
 	
-	/* User website, blog, web page */
-	public $webSiteURL = NULL;
-	
-	/* URL link to profile page on the IDp web site */
-	public $profileURL = NULL;
-
-	/* URL link to user photo or avatar */
-	public $photoURL = NULL;
-
-    /* Url link to user photo or avatar (bigger)*/
-    public $photoUrlBig = NULL;
-
-    /* Gender */
-	public $gender = null;
-	
-	/* The users last name */
-	public $firstName = null;
-
-	/* The users first name */
-	public $lastName = null;
-
-	/* User displayName provided by the IDp or a concatenation of first and last name */
-	public $displayName = NULL;
-	
-	/* A short about_me */
-	public $description = NULL;
-
-	/* The users primary work-company */
-	public $company = NULL;
-
-	/* the users title */
-	public $title = NULL;
-	
-	/* User email. Not all of IDp grant access to the user email */
-	public $email = NULL;
-	
-	/* Prvider id */
-	public $provider = NULL;
-	
-	/* For Xing & LinkedIn usually job-title @ main company */
-	public $headline = NULL;
-
-	/* array of tags associated with this user. Null if not yet loaded. */
-	public $tags = NULL;
-
     /**
-     * @param $provider
-     * @param string | null $gender
-     * @param string | null $firstName
-     * @param string | null $lastName
-     * @param string | null $identifier
-     * @param string | null $webSiteURL
-     * @param string | null $profileURL
-     * @param string | null $photoURL
-     * @param string | null $description
-     * @param string | null $email
-     * @param string | null $headline
-     * @param array | null $tags array of strings
+     * @param string $provider
      */
-    public function __construct($provider,
-								$gender = null,
-								$firstName = null, 
-								$lastName = null,
-								$identifier = null, 
-								$webSiteURL = null,
-								$profileURL = null,
-								$photoURL = null,
-								$description = null, 
-								$email = null,
-								$headline = null,
-								$company = null,
-								$title = null,
-								array $tags = null
-							){
-		$this->provider = $provider;
-		$this->firstName = $firstName;
-		$this->lastName = $lastName;
-	    $this->identifier = $identifier;
-		$this->webSiteURL = $webSiteURL;
-		$this->profileURL = $profileURL;
-		$this->photoURL = $photoURL;
-		$this->displayName = $firstName." ".$lastName;
-		$this->description = $description;
-		$this->email = $email;
-		$this->headline = $headline;
-		$this->company = $company;
-		$this->title = $title;
-		$this->tags = $tags;
+    public function __construct($provider)
+		{
+				$this->provider = $provider;
+		}
 
-	}
+		/**
+		 * @param mixed $key
+		 * @param mixed $value
+		 *
+		 * @return UserContact
+		 */
+		public function setField($key, $value)
+		{
+				$this->fields[$key] = $value;
+				return $this;
+		}
+
+		/**
+		 * @param mixed $key
+		 *
+		 * @return mixed|null
+		 */
+		public function getField($key)
+		{
+				if (array_key_exists($key, $this->fields))
+						return $this->fields[$key];
+		}
+
+		/**
+		 * @return array
+		 */
+		public function getFields()
+		{
+				return $this->fields;
+		}
 
 }
-

--- a/Services/AzineMergedBusinessNetworksProvider.php
+++ b/Services/AzineMergedBusinessNetworksProvider.php
@@ -287,48 +287,11 @@ class AzineMergedBusinessNetworksProvider {
 	 * @return UserContact
 	 */
     private function createUserContactFromXingProfile($xingProfile){
-        $newContact = new UserContact("Xing");
-        $newContact->identifier	    = (property_exists($xingProfile, 'id'))          	? $xingProfile->id                  : '';
-        $newContact->firstName 	    = (property_exists($xingProfile, 'first_name'))		? $xingProfile->first_name 	        : '';
-        $newContact->lastName		= (property_exists($xingProfile, 'last_name')) 		? $xingProfile->last_name 	        : '';
-        $newContact->displayName	= $newContact->firstName." ".$newContact->lastName;
-        $newContact->profileURL	    = (property_exists($xingProfile, 'permalink'))   	? $xingProfile->permalink           : '';
-        $newContact->photoURL       = (property_exists($xingProfile, 'photo_urls'))   	? $xingProfile->photo_urls->size_96x96   : '';
-        $newContact->photoUrlBig    = (property_exists($xingProfile, 'photo_urls'))   	? $xingProfile->photo_urls->size_256x256   : '';
-        $newContact->description	= (property_exists($xingProfile, 'interests'))   	? $xingProfile->interests           : '';
-        $newContact->description	.= (property_exists($xingProfile, 'haves'))   	    ? "\n".$xingProfile->haves           : '';
-        $newContact->description	.= (property_exists($xingProfile, 'wants'))   	    ? "\n".$xingProfile->wants           : '';
-        $newContact->email			= (property_exists($xingProfile, 'active_email'))	? $xingProfile->active_email        : '';
-        $newContact->gender		    = (property_exists($xingProfile, 'gender'))			? $xingProfile->gender              : '';
-        $primaryCompany             = (property_exists($xingProfile, 'professional_experience') && property_exists($xingProfile->professional_experience, 'primary_company')) ? $xingProfile->professional_experience->primary_company : null;
-        // company name and title are not always available.
-        if($primaryCompany) {
-			$newContact->company = (property_exists($primaryCompany, 'name'))	? $primaryCompany->name        : '';
-			$newContact->title = (property_exists($primaryCompany, 'title'))	? $primaryCompany->title        : '';
-            if($newContact->title && $newContact->company) {
-                $newContact->headline = $newContact->title . " @ " . $newContact->company;
-            } else {
-                $newContact->headline = $newContact->title . $newContact->company;
-            }
-        }
+				$newContact = new UserContact("Xing");
 
-        // My own priority: Homepage, blog, other, something else.
-        if (property_exists($xingProfile, 'web_profiles')) {
-            $newContact->webSiteURL = (property_exists($xingProfile->web_profiles, 'homepage')) ? $xingProfile->web_profiles->homepage[0] : null;
-            if (null === $newContact->webSiteURL) {
-                $newContact->webSiteURL = (property_exists($xingProfile->web_profiles, 'blog')) ? $xingProfile->web_profiles->blog[0] : null;
-            }
-            if (null === $newContact->webSiteURL) {
-                $newContact->webSiteURL = (property_exists($xingProfile->web_profiles, 'other')) ? $xingProfile->web_profiles->other[0] : null;
-            }
-            // Just use *anything*!
-            if (null === $newContact->webSiteURL) {
-                foreach ($xingProfile->web_profiles as $aUrl) {
-                    $newContact->webSiteURL = $aUrl[0];
-                    break;
-                }
-            }
-        }
+				foreach ($xingProfile as $key => $value)  {
+						$newContact->setField($key, $value);
+				}
 
         return $newContact;
     }


### PR DESCRIPTION
Hello,

so I added a field in the config called `fields` for the user to decide which fields of contacts should be retrieved. Example config for xing

```
azine_hybrid_auth:
    providers:
        xing:
            fields:
                - active_email
                - first_name
                - last_name
                - gender
                - professional_experience.primary_company
```

Of course, as it currently stands, this is no "real" improvement, as the `UserContact` will only be filled with the hardcoded parameters. Making this dynamic is an even greater change, so I thought, I'd start only with this pull request.
